### PR TITLE
remove grpcio-tools specified version and other dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-certifi==2022.9.24
-charset-normalizer==2.1.1
-grpcio==1.49.1
-grpcio-tools==1.38.1
-idna==3.4
-protobuf==3.20.3
-requests==2.28.1
-six==1.16.0
-urllib3==1.26.12
+grpcio-tools~=1.51.3
+requests~=2.28.2
+six~=1.16.0


### PR DESCRIPTION
Delete redundant dependent libraries, because those dependent libraries will be installed automatically. If not deleted, the compilation step will be executed, which will eventually cause the installation to fail on the python:alpine version docker iamge